### PR TITLE
Corrected repositories and cloudbuild files JIRA SALUS-340

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,9 +27,9 @@ steps:
     - name: user.home
       path: /root
 
-  - id: DEPLOY
+  - id: VERIFY
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', '-s', '.mvn/settings.xml']
+    args: ['verify', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home
       path: /root
@@ -37,7 +37,7 @@ steps:
   # Saves the files to the GCS cache.
   - id: PUSH_UP_CACHE
     waitFor:
-    - DEPLOY
+    - VERIFY
     name: gcr.io/cloud-builders/gsutil
     dir: /root
     entrypoint: bash

--- a/pom.xml
+++ b/pom.xml
@@ -115,12 +115,44 @@
         </plugins>
     </build>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <name>artifactory-artifactory-0-snapshots</name>
-            <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot-local</url>
-        </snapshotRepository>
-    </distributionManagement>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>salus-dev-snapshots</id>
+      <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot-local</url>
+    </snapshotRepository>
+    <repository>
+      <id>salus-dev-release</id>
+      <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release-local</url>
+    </repository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>salus-dev-release</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release</url>
+    </repository>
+    <repository>
+      <snapshots />
+      <id>salus-dev-snapshots</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>salus-dev-release</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release</url>
+    </pluginRepository>
+    <pluginRepository>
+      <snapshots />
+      <id>salus-dev-snapshots</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot</url>
+    </pluginRepository>
+  </pluginRepositories>
 
 </project>


### PR DESCRIPTION
# Resolves
SALUS-340

# What
Correcting the repos that are in Artifactory.
Updated cloudbuild files to ensure only deploying in specific cases, otherwise just doing a `mvn verify`

Also ensured there are 3 cloudbuild triggers (tags, master = cloudbuild-deploy.yaml, any branch = cloudbuild.yaml)
