### PR TITLE
Organize classes into packages and update auth logic

### DIFF
--- a/src/main/java/com/rackspace/salus/authservice/config/AuthProperties.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/AuthProperties.java
@@ -16,17 +16,22 @@
  *
  */
 
-package com.rackspace.salus.authservice;
+package com.rackspace.salus.authservice.config;
 
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
-import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
-@Configuration
-@EnableGlobalMethodSecurity(
-  prePostEnabled = true, 
-  securedEnabled = true, 
-  jsr250Enabled = true)
-public class MethodSecurityConfig 
-  extends GlobalMethodSecurityConfiguration {
+@ConfigurationProperties("auth.service")
+@Component
+@Data
+public class AuthProperties {
+
+  /**
+   * The roles (without "ROLE_" prefix) that are required to allow the envoy to connect to the auth service.
+   * Identity roles are translated to this format via {@link com.rackspace.salus.common.web.PreAuthenticatedFilter}.
+   *
+   * COMPUTE_DEFAULT is what is used in tests.
+   */
+  String[] roles = new String[]{"COMPUTE_DEFAULT"};
 }

--- a/src/main/java/com/rackspace/salus/authservice/config/MethodSecurityConfig.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/MethodSecurityConfig.java
@@ -16,16 +16,17 @@
  *
  */
 
-package com.rackspace.salus.authservice;
+package com.rackspace.salus.authservice.config;
+
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
-import org.springframework.vault.config.EnvironmentVaultConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
 
 @Configuration
- @Import(EnvironmentVaultConfiguration.class)
- // This is required to allow mocking of vault during test programs
- @Profile("!test")
- public class VaultConfig {
- }
-  
+@EnableGlobalMethodSecurity(
+  prePostEnabled = true, 
+  securedEnabled = true, 
+  jsr250Enabled = true)
+public class MethodSecurityConfig 
+  extends GlobalMethodSecurityConfiguration {
+}

--- a/src/main/java/com/rackspace/salus/authservice/config/VaultConfig.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/VaultConfig.java
@@ -16,12 +16,16 @@
  *
  */
 
-package com.rackspace.salus.authservice;
+package com.rackspace.salus.authservice.config;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.vault.config.EnvironmentVaultConfiguration;
 
-import lombok.Data;
-@Data
-public class CertResponse {
-  final String certificate;
-  final String issuingCaCertificate;
-  final String privateKey;
-}
+@Configuration
+ @Import(EnvironmentVaultConfiguration.class)
+ // This is required to allow mocking of vault during test programs
+ @Profile("!test")
+ public class VaultConfig {
+ }
+  

--- a/src/main/java/com/rackspace/salus/authservice/config/WebConfig.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/WebConfig.java
@@ -16,26 +16,41 @@
  *
  */
 
-package com.rackspace.salus.authservice;
+package com.rackspace.salus.authservice.config;
 
 import com.rackspace.salus.common.web.ReposeHeaderFilter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 /**
  * @author Geoff Bourne
  * @since Mar 2017
  */
 @Configuration
+@Slf4j
 public class WebConfig extends WebSecurityConfigurerAdapter {
+
+    private final AuthProperties authProperties;
+
+    public WebConfig(AuthProperties authProperties) {
+        this.authProperties = authProperties;
+    }
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.addFilterBefore(new ReposeHeaderFilter(), UsernamePasswordAuthenticationFilter.class);
+        log.debug("Configuring web security to authorize roles: {}", authProperties.getRoles());
+        http
+            .csrf().disable()
+            .addFilterBefore(
+                new ReposeHeaderFilter(),
+                BasicAuthenticationFilter.class
+            )
+            .authorizeRequests()
+            .antMatchers("/auth/**")
+            .hasAnyRole(authProperties.getRoles());
 
-        http.antMatcher("/auth/**")
-                .authorizeRequests()
-                .anyRequest().authenticated();
     }
 }

--- a/src/main/java/com/rackspace/salus/authservice/web/CertResponse.java
+++ b/src/main/java/com/rackspace/salus/authservice/web/CertResponse.java
@@ -1,0 +1,27 @@
+/*
+ *    Copyright 2018 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package com.rackspace.salus.authservice.web;
+
+import lombok.Data;
+@Data
+public class CertResponse {
+  final String certificate;
+  final String issuingCaCertificate;
+  final String privateKey;
+}

--- a/src/main/java/com/rackspace/salus/authservice/web/controller/AuthController.java
+++ b/src/main/java/com/rackspace/salus/authservice/web/controller/AuthController.java
@@ -16,8 +16,9 @@
  *
  */
 
-package com.rackspace.salus.authservice;
+package com.rackspace.salus.authservice.web.controller;
 
+import com.rackspace.salus.authservice.web.CertResponse;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/com/rackspace/salus/authservice/AuthControllerTest.java
+++ b/src/test/java/com/rackspace/salus/authservice/AuthControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.vault.core.VaultPkiOperations;


### PR DESCRIPTION
# What

Makes the auth service auth more consistent with admin/public apis.

The only real changes are in WebConfig.  The rest is just making the repo structure a little cleaner.

# How

Copy/paste from apis, tweak the path, and add a properties file.

## How to test

Run tests.  I added the test role to the properties file because spring is really weird about configuring it any other way.  I think we've seen in the past that certain things you should be able to do, we can't, because we use yaml instead of properties.

We'll deploy to double check this too.

# Why

To make things less confusing.  If everything works the same it is easier to debug.

# TODO

Add property to helm.