### PR TITLE
Include stdout logging when production profile is activated

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,6 +34,7 @@
   <root level="INFO">
     <springProfile name="production">
       <appender-ref ref="FLUENCY" />
+      <appender-ref ref="STDOUT"/>
     </springProfile>
     <springProfile name="!production">
       <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
# What

Include stdout logging when production profile is activated so that we can better troubleshoot when fluency logback appender fails.