### PR TITLE
remove stdout

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -27,7 +27,6 @@
   <root level="INFO">
     <springProfile name="production">
       <appender-ref ref="FLUENCY" />
-      <appender-ref ref="STDOUT"/>
     </springProfile>
     <springProfile name="!production">
       <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
the other logback configs don't seem to use stdout:   https://github.com/racker/salus-telemetry-monitor-management/blob/master/src/main/resources/logback-spring.xml

and it is causing this error:
ERROR in ch.qos.logback.core.joran.action.AppenderRefAction - Could not find an appender named [STDOUT]. Did you define it below instead of above in the configuration file?
