### PR TITLE
Added log within ClientCertificateService to improve cache-wise visibility

### DIFF
--- a/src/main/java/com/rackspace/salus/authservice/services/ClientCertificateService.java
+++ b/src/main/java/com/rackspace/salus/authservice/services/ClientCertificateService.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.authservice.services;
 
 import com.rackspace.salus.authservice.config.AuthProperties;
 import com.rackspace.salus.authservice.web.CertResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ import org.springframework.vault.support.VaultCertificateRequest;
 import org.springframework.vault.support.VaultCertificateResponse;
 
 @Service
+@Slf4j
 public class ClientCertificateService {
 
   private final VaultTemplate vaultTemplate;
@@ -39,6 +41,8 @@ public class ClientCertificateService {
 
   @Cacheable("clientCerts")
   public CertResponse getClientCertificate(String tenant) {
+    log.info("Allocating client certificates for tenant={} from Vault", tenant);
+
     final VaultCertificateResponse resp = vaultTemplate.opsForPki()
         .issueCertificate(
             properties.getPkiRoleName(),

--- a/src/main/java/com/rackspace/salus/authservice/web/controller/AuthController.java
+++ b/src/main/java/com/rackspace/salus/authservice/web/controller/AuthController.java
@@ -49,7 +49,7 @@ public class AuthController {
         final CertResponse rd = clientCertificateService.getClientCertificate(tenant);
 
         certCounter.increment();
-        log.info("Retrieving client certificates for tenant={}", tenant);
+        log.info("Providing client certificates for tenant={}", tenant);
         return ResponseEntity.ok(rd);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,4 +13,4 @@ spring:
     cache-names: clientCerts
     caffeine:
       # Placeholders can be configured by env vars: SALUS_CERTCACHE_MAXSIZE, SALUS_CERTCACHE_TTL
-      spec: maximumSize=${salus.cert-cache.max-size:500},expireAfterAccess=${salus.cert-cache.ttl:600s}
+      spec: maximumSize=${salus.cert-cache.max-size:500},expireAfterWrite=${salus.cert-cache.ttl:600s}

--- a/src/test/java/com/rackspace/salus/authservice/services/ClientCertificateServiceTest.java
+++ b/src/test/java/com/rackspace/salus/authservice/services/ClientCertificateServiceTest.java
@@ -42,6 +42,7 @@ import org.springframework.vault.support.VaultCertificateResponse;
 @RunWith(SpringRunner.class)
 @SpringBootTest(
     properties = {
+        // explicitly configure cache to hold more than the one tenant tested and no TTL
         "spring.cache.caffeine.spec=maximumSize=10",
         "salus.auth.service.pki-role-name=testing-role"
     }


### PR DESCRIPTION
# What

After caching was introduced, the only log statement was in the REST controller, which emits a log on every request. It would be nice to have a separate log statement to see when a cache-miss happened and Vault is getting called.

# How

Adjusted the log message wording in the controller and added a log in the service.

While I was in there I thought I'd change the default expiration parameter to "afterWrite" rather than "afterAccess" to ensure that ongoing requests from the same tenant didn't accidentally keep a cert alive beyond it's allowed lifetime.