### PR TITLE
Added auto-config of app metrics

### DIFF
--- a/src/main/java/com/rackspace/salus/authservice/TelemetryAuthServiceApplication.java
+++ b/src/main/java/com/rackspace/salus/authservice/TelemetryAuthServiceApplication.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.authservice;
 
+import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -23,6 +24,7 @@ import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
 @EnableCaching
+@AutoConfigureSalusAppMetrics
 public class TelemetryAuthServiceApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-801

# What

This application wasn't yet customizing the MeterRegistry tags with `app` and `host` to qualify the application/pod instance.

# How

Use the auto-config from https://github.com/racker/salus-common/pull/50

# How to test

Existing tests