### PR TITLE
Use list for roles instead of array

### DIFF
--- a/src/main/java/com/rackspace/salus/authservice/config/AuthProperties.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/AuthProperties.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.authservice.config;
 
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -31,7 +32,7 @@ public class AuthProperties {
    *
    * COMPUTE_DEFAULT is what is used in tests.
    */
-  String[] roles = new String[]{"COMPUTE_DEFAULT"};
+  List<String> roles = List.of("COMPUTE_DEFAULT");
 
   /**
    * The Vault role name provided during PKI certificate issuing requests.

--- a/src/main/java/com/rackspace/salus/authservice/config/WebConfig.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/WebConfig.java
@@ -50,7 +50,7 @@ public class WebConfig extends WebSecurityConfigurerAdapter {
             )
             .authorizeRequests()
             .antMatchers("/auth/**")
-            .hasAnyRole(authProperties.getRoles());
+            .hasAnyRole(authProperties.getRoles().toArray(new String[0]));
 
     }
 }


### PR DESCRIPTION
Same as https://github.com/racker/salus-telemetry-api/pull/73 and https://github.com/racker/salus-telemetry-api/pull/74

The current data type does not allow for a list of roles to be specified via environment variables. This fixes it.


---

With these environment variables
```
SALUS_AUTH_SERVICE_ROLES_0_=OBSERVER
SALUS_AUTH_SERVICE_ROLES_1_=TEST
```

and with this changes roles get read like so
```
Configuring web security to authorize roles: [OBSERVER, TEST]
```

Without it the logs show
```
Configuring web security to authorize roles: OBSERVER
```