### PR TITLE
Switched caching framework from Caffeine to Ehcache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,12 @@
       <artifactId>spring-boot-starter-cache</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/rackspace/salus/authservice/config/CacheConfig.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/CacheConfig.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.authservice.config;
 
+import com.google.common.collect.Iterables;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.ExpiryPolicyBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
@@ -40,15 +41,20 @@ public class CacheConfig {
   @Bean
   public JCacheManagerCustomizer cacheCustomizer() {
     return cacheManager -> {
-      cacheManager.createCache(
-          "clientCerts",
-          Eh107Configuration.fromEhcacheCacheConfiguration(
-              CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class,
-                  ResourcePoolsBuilder.heap(properties.getMaxSize())
-              )
-                  .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(properties.getTtl()))
-          )
-      );
+
+      // Unit testing causes cache customizer to be invoked more than once, so guard against duplicate cache exception
+      if (!Iterables.contains(cacheManager.getCacheNames(), "clientCerts")) {
+        cacheManager.createCache(
+            "clientCerts",
+            Eh107Configuration.fromEhcacheCacheConfiguration(
+                CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class,
+                    ResourcePoolsBuilder.heap(properties.getMaxSize())
+                )
+                    .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(properties.getTtl()))
+            )
+        );
+      }
+
     };
   }
 }

--- a/src/main/java/com/rackspace/salus/authservice/config/CacheConfig.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/CacheConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.authservice.config;
+
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.cache.JCacheManagerCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+  private final CacheProperties properties;
+
+  @Autowired
+  public CacheConfig(CacheProperties properties) {
+    this.properties = properties;
+  }
+
+  @Bean
+  public JCacheManagerCustomizer cacheCustomizer() {
+    return cacheManager -> {
+      cacheManager.createCache(
+          "clientCerts",
+          Eh107Configuration.fromEhcacheCacheConfiguration(
+              CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class,
+                  ResourcePoolsBuilder.heap(properties.getMaxSize())
+              )
+                  .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(properties.getTtl()))
+          )
+      );
+    };
+  }
+}

--- a/src/main/java/com/rackspace/salus/authservice/config/CacheProperties.java
+++ b/src/main/java/com/rackspace/salus/authservice/config/CacheProperties.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.authservice;
+package com.rackspace.salus.authservice.config;
 
-import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
-import com.rackspace.salus.common.util.DumpConfigProperties;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.stereotype.Component;
 
-@SpringBootApplication
-@AutoConfigureSalusAppMetrics
-public class TelemetryAuthServiceApplication {
-
-	public static void main(String[] args) {
-		DumpConfigProperties.process(args);
-
-		SpringApplication.run(TelemetryAuthServiceApplication.class, args);
-	}
+@ConfigurationProperties("salus.auth.cache")
+@Component
+@Data
+public class CacheProperties {
+  int maxSize = 500;
+  @DurationUnit(ChronoUnit.SECONDS)
+  Duration ttl = Duration.ofSeconds(600);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,3 @@ management:
 spring:
   application:
     name: salus-telemetry-auth-service
-  cache:
-    cache-names: clientCerts
-    caffeine:
-      # Placeholders can be configured by env vars: SALUS_CERTCACHE_MAXSIZE, SALUS_CERTCACHE_TTL
-      spec: maximumSize=${salus.cert-cache.max-size:500},expireAfterWrite=${salus.cert-cache.ttl:600s}

--- a/src/test/java/com/rackspace/salus/authservice/services/ClientCertificateServiceTest.java
+++ b/src/test/java/com/rackspace/salus/authservice/services/ClientCertificateServiceTest.java
@@ -43,7 +43,7 @@ import org.springframework.vault.support.VaultCertificateResponse;
 @SpringBootTest(
     properties = {
         // explicitly configure cache to hold more than the one tenant tested and no TTL
-        "spring.cache.caffeine.spec=maximumSize=10",
+        "salus.auth.cache.max-size=10",
         "salus.auth.service.pki-role-name=testing-role"
     }
 )


### PR DESCRIPTION
# What

Since Ehcache was used in https://github.com/racker/salus-policy-management/pull/25 I thought it would be good to be consistent and switch the caching framework here to Ehcache also.

# How

Used the same config bean approach to programmatically configure the cache in order to reference Spring properties.

# How to test

Existing unit tests