### PR TITLE
Revert "Fix test"

### DIFF
--- a/src/test/java/com/rackspace/salus/authservice/AuthControllerTest.java
+++ b/src/test/java/com/rackspace/salus/authservice/AuthControllerTest.java
@@ -61,7 +61,7 @@ public class AuthControllerTest {
 
       HttpHeaders h = new HttpHeaders();
       h.add("X-Roles", "compute:default");
-      h.add("Requested-Tenant-Id", "123456");
+      h.add("X-Tenant-Id", "123456");
       mvc.perform(
                get("/auth/cert")
                    .headers(h))
@@ -80,7 +80,7 @@ public class AuthControllerTest {
    public void getCertBadRole() throws Exception {
       HttpHeaders h = new HttpHeaders();
       h.add("X-Roles", "compute:not-default");
-      h.add("Requested-Tenant-Id", "123456");
+      h.add("X-Tenant-Id", "123456");
       mvc.perform(
               get("/auth/cert")
                   .headers(h))


### PR DESCRIPTION
Reverts racker/salus-telemetry-auth-service#26

We're reverting the common change - https://github.com/racker/salus-common/pull/53