### PR TITLE
Added versioned/tenant form of auth cert API mapping

### DIFF
--- a/src/main/java/com/rackspace/salus/authservice/web/controller/AuthController.java
+++ b/src/main/java/com/rackspace/salus/authservice/web/controller/AuthController.java
@@ -25,12 +25,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/auth")
 public class AuthController {
 
     private final ClientCertificateService clientCertificateService;
@@ -44,12 +43,20 @@ public class AuthController {
         certCounter = meterRegistry.counter("messages","certsAssigned", "stage");
     }
 
-    @GetMapping("cert")
-    public ResponseEntity<CertResponse> getCert(@AuthenticationPrincipal String tenant) {
-        final CertResponse rd = clientCertificateService.getClientCertificate(tenant);
+    @GetMapping("/v${salus.api.auth.version}/tenant/{tenantId}/auth/cert")
+    public ResponseEntity<CertResponse> getCert(@PathVariable String tenantId) {
+        final CertResponse rd = clientCertificateService.getClientCertificate(tenantId);
 
         certCounter.increment();
-        log.info("Providing client certificates for tenant={}", tenant);
+        log.info("Providing client certificates for tenant={}", tenantId);
         return ResponseEntity.ok(rd);
+    }
+
+    /**
+     * @deprecated retained temporarily to allow for Envoy migration to versioned, tenant-based path
+     */
+    @GetMapping("/auth/cert")
+    public ResponseEntity<CertResponse> getCertWithTenantFromAuth(@AuthenticationPrincipal String tenantId) {
+        return getCert(tenantId);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
-
+salus:
+  api:
+    auth:
+      version: "1.0"
 management:
   metrics:
     export:

--- a/src/test/java/com/rackspace/salus/authservice/AuthControllerTest.java
+++ b/src/test/java/com/rackspace/salus/authservice/AuthControllerTest.java
@@ -63,6 +63,34 @@ public class AuthControllerTest {
       h.add("X-Roles", "compute:default");
       h.add("X-Tenant-Id", "123456");
       mvc.perform(
+               get("/v1.0/tenant/123456/auth/cert")
+                   .headers(h))
+                   .andExpect(status().is(200))
+                   .andExpect(jsonPath("$.certificate",
+                       is("-----BEGIN CERTIFICATE-----\ncert\n-----END CERTIFICATE-----")))
+                   .andExpect(jsonPath("$.issuingCaCertificate",
+                       is("-----BEGIN CERTIFICATE-----\nica\n-----END CERTIFICATE-----")))
+                   .andExpect(jsonPath("$.privateKey",
+                       is("-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----")));
+
+      verify(clientCertificateService).getClientCertificate("123456");
+   }
+
+   @Test
+   public void getCertSuccessful_oldPath() throws Exception {
+
+      final CertResponse certResponse = new CertResponse(
+          "-----BEGIN CERTIFICATE-----\ncert\n-----END CERTIFICATE-----",
+          "-----BEGIN CERTIFICATE-----\nica\n-----END CERTIFICATE-----",
+          "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----"
+      );
+      when(clientCertificateService.getClientCertificate(any()))
+          .thenReturn(certResponse);
+
+      HttpHeaders h = new HttpHeaders();
+      h.add("X-Roles", "compute:default");
+      h.add("X-Tenant-Id", "123456");
+      mvc.perform(
                get("/auth/cert")
                    .headers(h))
                    .andExpect(status().is(200))


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-602

# What

- Since Identity users may potentially be associated with more than one tenant, the authentication cert request should really be qualified by tenant to avoid ambiguity
- The Repose configuration currently differs for the auth service vs admin/public APIs since the latter use the typical Rackspace API paths with a version prefix and tenant in the path. It would be good to use consistent configuration across all of the externally facing APIs

# How

Copied and tweaked the controller method to accept the tenant ID as a path variable. I also left the existing mapping, but had that method simply invoke the other. Even though we're not in production, I still felt it would be a bit too messy having a chunk of our own Envoys potentially crash looping and triggering PD alerts. 

After we upgrade all of the Envoys we can do a small change to remove the`getCertWithTenantFromAuth` request mapping.

# How to test

Updated the unit tests to cover both of the request mappings.