### PR TITLE
Enable tenant id verification

### DIFF
--- a/src/main/java/com/rackspace/salus/authservice/TelemetryAuthServiceApplication.java
+++ b/src/main/java/com/rackspace/salus/authservice/TelemetryAuthServiceApplication.java
@@ -18,10 +18,12 @@ package com.rackspace.salus.authservice;
 
 import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
 import com.rackspace.salus.common.util.DumpConfigProperties;
+import com.rackspace.salus.telemetry.web.EnableTenantVerification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@EnableTenantVerification
 @AutoConfigureSalusAppMetrics
 public class TelemetryAuthServiceApplication {
 

--- a/src/test/java/com/rackspace/salus/authservice/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/rackspace/salus/authservice/web/controller/AuthControllerTest.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.rackspace.salus.authservice.services.ClientCertificateService;
 import com.rackspace.salus.authservice.services.TokenService;
 import com.rackspace.salus.authservice.web.CertResponse;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
@@ -63,6 +64,9 @@ public class AuthControllerTest {
 
   @MockBean
   TokenService tokenService;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void getCertSuccessful() throws Exception {


### PR DESCRIPTION
See https://github.com/racker/salus-telemetry-model/pull/124

Utilizes the `@EnableTenantVerification` annotations and adds some simple tests to show it took effect.